### PR TITLE
fix(animation): ensure `build()` can re-run animation

### DIFF
--- a/lib/countup.dart
+++ b/lib/countup.dart
@@ -64,6 +64,7 @@ class _CountupState extends State<Countup> with TickerProviderStateMixin {
         CurvedAnimation(parent: _controller, curve: widget.curve);
     _animation = Tween<double>(begin: widget.begin, end: widget.end)
         .animate(curvedAnimation);
+    _controller.reset();
     _controller.forward();
 
     return _CountupAnimatedText(


### PR DESCRIPTION
A side effect of #1 was that animations occasionally only ran once. Hence, resetting the animation controller before being played on build.

Sorry for failing to notice this in the last PR.